### PR TITLE
Allow pressure to use a non-default units

### DIFF
--- a/ecowitt_sensor.groovy
+++ b/ecowitt_sensor.groovy
@@ -165,6 +165,9 @@ metadata {
     if (decsPressure != null) {
       input(name: "decsPressure", type: "number", title: "<font style='font-size:12px; color:#1a77c9'>Pressure decimals</font>", description: "<font style='font-size:12px; font-style: italic'>Enter a single digit number or -1 for no rounding</font>");
     }
+    if (decsPressure != null) {
+      input(name: 'decsPressureUnits', type: 'enum', title: "<font style='font-size:12px; color:#1a77c9'>Pressure units</font>", description: "<font style='font-size:12px; font-style: italic'>Select the units for pressure</font>", defaultValue: pressureUnitDefault(), options: ['inHg','hPa'])
+    }
   }
 }
 
@@ -233,6 +236,13 @@ private Boolean unitSystemIsMetric() {
   return (getParent().unitSystemIsMetric());
 }
 
+private String pressureUnitDefault() {
+    if (unitSystemIsMetric()) {
+        return "hPa"
+    } else {
+        return "inHg"
+    }
+}
 // ------------------------------------------------------------
 
 private String timeEpochToLocal(String time) {
@@ -666,7 +676,7 @@ private Boolean attributeUpdatePressure(String val, String attribPressure, Strin
   BigDecimal relative = absolute * Math.pow(1 - ((altitude * 0.0065) / (temperature + (altitude * 0.0065) + 273.15)), -5.257);
 
   // Convert to imperial if requested
-  if (metric) val = "hPa";
+  if (metric || settings.decsPressureUnits == "hPa") val = "hPa";
   else {
     absolute = convert_hPa_to_inHg(absolute);
     relative = convert_hPa_to_inHg(relative);


### PR DESCRIPTION
This allows pressure to select hPa even when using Imperial units.  It's quick and dirty but it seems to work ok.
Please let me know if there is anything you'd do differently.
Thanks!